### PR TITLE
fix(zerolog): GetLogger() returns error if logger is of incorrect type

### DIFF
--- a/zerolog/README.md
+++ b/zerolog/README.md
@@ -62,7 +62,7 @@ func main () {
 	
     hlog.SetLogger(hertzZerolog.New(
         hertzZerolog.WithOutput(os.Stdout), // allows to specify output
-        hertzZerolog.WithLevel(hlog.LevelWarn), // option with log level
+        hertzZerolog.WithLevel(hlog.LevelInfo), // option with log level
 	hertzZerolog.WithTimestamp(), // option with timestamp
 	hertzZerolog.WithCaller())) // option with caller
 

--- a/zerolog/README.md
+++ b/zerolog/README.md
@@ -89,20 +89,21 @@ import (
 )
 
 // RequestIDHeaderValue value for the request id header
-const RequestIDHeaderValue = "X-Request-Id"
+const RequestIDHeaderValue = "X-Request-ID"
 
 // LoggerMiddleware middleware for logging incoming requests
 func LoggerMiddleware() app.HandlerFunc {
     return func(c context.Context, ctx *app.RequestContext) {
         start := time.Now()
-        
-        reqId := ctx.Request.Header.Get(RequestIDHeaderValue)
-        if reqId == "" {
-            reqId = c.Value(RequestIDHeaderValue).(string)
+
+        logger, err := hertzZerolog.GetLogger()
+        if err != nil {
+            hlog.Error(err)
+            ctx.Next(c)
+            return
         }
-        
-        logger := hertzZerolog.GetLogger()
-        
+
+        reqId := c.Value(RequestIDHeaderValue).(string)
         if reqId != "" {
             logger = logger.WithField("request_id", reqId)
         }

--- a/zerolog/logger.go
+++ b/zerolog/logger.go
@@ -47,7 +47,7 @@ func From(log zerolog.Logger, options ...Opt) *Logger {
 	return newLogger(log, options)
 }
 
-// GetLogger returns the default logger instance
+// GetLogger returns the default logger instance or error if not of type zerolog.Logger
 func GetLogger() (*Logger, error) {
 	hlogLogger := hlog.DefaultLogger()
 

--- a/zerolog/logger.go
+++ b/zerolog/logger.go
@@ -18,6 +18,7 @@ package zerolog
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -41,21 +42,20 @@ func New(options ...Opt) *Logger {
 	return newLogger(zerolog.New(os.Stdout), options)
 }
 
-// From returns a new Logger instance using existing zerolog log.
+// From returns a new Logger instance using an existing logger
 func From(log zerolog.Logger, options ...Opt) *Logger {
 	return newLogger(log, options)
 }
 
 // GetLogger returns the default logger instance
-func GetLogger() *Logger {
+func GetLogger() (*Logger, error) {
 	hlogLogger := hlog.DefaultLogger()
-	if hlogLogger != nil {
-		if logger, ok := hlogLogger.(*Logger); ok {
-			return logger
-		}
-	}
 
-	return nil
+	if logger, ok := hlogLogger.(*Logger); ok {
+		return logger, nil
+	} else {
+		return nil, errors.New("hlog.DefaultLogger is not a zerolog logger")
+	}
 }
 
 // SetLevel setting logging level for logger

--- a/zerolog/logger_test.go
+++ b/zerolog/logger_test.go
@@ -46,8 +46,9 @@ func TestFrom(t *testing.T) {
 
 func TestGetLogger(t *testing.T) {
 	hlog.SetLogger(New())
-	logger := GetLogger()
+	logger, err := GetLogger()
 
+	assert.NoError(t, err)
 	assert.IsType(t, &Logger{}, logger)
 }
 

--- a/zerolog/logger_test.go
+++ b/zerolog/logger_test.go
@@ -44,6 +44,14 @@ func TestFrom(t *testing.T) {
 	)
 }
 
+func TestGetLogger_hlogNotSet_shouldReturnError(t *testing.T) {
+	logger, err := GetLogger()
+
+	assert.Nil(t, logger)
+	assert.Error(t, err)
+	assert.Equal(t, "hlog.DefaultLogger is not a zerolog logger", err.Error())
+}
+
 func TestGetLogger(t *testing.T) {
 	hlog.SetLogger(New())
 	logger, err := GetLogger()


### PR DESCRIPTION
#### What type of PR is this?

Improvement to avoid potential nil reference when using GetLogger().

#### What this PR does / why we need it (English/Chinese):

Adds error return to GetLogger() function if the default logger is of incorrect type.