### PR TITLE
fix(zerolog): Bigfixes for concurrency safety

### DIFF
--- a/zerolog/README.md
+++ b/zerolog/README.md
@@ -33,7 +33,7 @@ func main () {
     hlog.SetLogger(hertzZerolog.New())
 
     h.GET("/ping", func(ctx context.Context, c *app.RequestContext) {
-        hlog.Info("test log")
+        hlog.Warn("test log")
         c.JSON(consts.StatusOK, utils.H{"ping": "pong"})
     })
 	
@@ -102,7 +102,7 @@ func LoggerMiddleware() app.HandlerFunc {
             ctx.Next(c)
             return
         }
-
+        
         reqId := c.Value(RequestIDHeaderValue).(string)
         if reqId != "" {
             logger = logger.WithField("request_id", reqId)
@@ -112,8 +112,9 @@ func LoggerMiddleware() app.HandlerFunc {
         
         defer func() {
             stop := time.Now()
-            
-            logger.Unwrap().Info().
+
+            logUnwrap := logger.Unwrap()
+            logUnwrap.Info().
                 Str("remote_ip", ctx.ClientIP()).
                 Str("method", string(ctx.Method())).
                 Str("path", string(ctx.Path())).

--- a/zerolog/logger.go
+++ b/zerolog/logger.go
@@ -47,15 +47,15 @@ func From(log zerolog.Logger, options ...Opt) *Logger {
 	return newLogger(log, options)
 }
 
-// GetLogger returns the default logger instance or error if not of type zerolog.Logger
-func GetLogger() (*Logger, error) {
-	hlogLogger := hlog.DefaultLogger()
+// GetLogger returns the default logger instance
+func GetLogger() (Logger, error) {
+	defaultLogger := hlog.DefaultLogger()
 
-	if logger, ok := hlogLogger.(*Logger); ok {
-		return logger, nil
-	} else {
-		return nil, errors.New("hlog.DefaultLogger is not a zerolog logger")
+	if logger, ok := defaultLogger.(*Logger); ok {
+		return *logger, nil
 	}
+
+	return Logger{}, errors.New("hlog.DefaultLogger is not a zerolog logger")
 }
 
 // SetLevel setting logging level for logger
@@ -77,14 +77,14 @@ func (l *Logger) WithContext(ctx context.Context) context.Context {
 }
 
 // WithField appends a field to the logger
-func (l *Logger) WithField(key string, value interface{}) *Logger {
+func (l *Logger) WithField(key string, value interface{}) Logger {
 	l.log = l.log.With().Interface(key, value).Logger()
-	return l
+	return *l
 }
 
 // Unwrap returns the underlying zerolog logger
-func (l *Logger) Unwrap() *zerolog.Logger {
-	return &l.log
+func (l *Logger) Unwrap() zerolog.Logger {
+	return l.log
 }
 
 // Log log using zerolog logger with specified level

--- a/zerolog/logger_test.go
+++ b/zerolog/logger_test.go
@@ -44,10 +44,9 @@ func TestFrom(t *testing.T) {
 	)
 }
 
-func TestGetLogger_hlogNotSet_shouldReturnError(t *testing.T) {
-	logger, err := GetLogger()
+func TestGetLogger_notSet(t *testing.T) {
+	_, err := GetLogger()
 
-	assert.Nil(t, logger)
 	assert.Error(t, err)
 	assert.Equal(t, "hlog.DefaultLogger is not a zerolog logger", err.Error())
 }
@@ -57,7 +56,7 @@ func TestGetLogger(t *testing.T) {
 	logger, err := GetLogger()
 
 	assert.NoError(t, err)
-	assert.IsType(t, &Logger{}, logger)
+	assert.IsType(t, Logger{}, logger)
 }
 
 func TestWithContext(t *testing.T) {
@@ -98,7 +97,7 @@ func TestUnwrap(t *testing.T) {
 	logger := l.Unwrap()
 
 	assert.NotNil(t, logger)
-	assert.IsType(t, &zerolog.Logger{}, logger)
+	assert.IsType(t, zerolog.Logger{}, logger)
 }
 
 func TestLog(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

fix: Some methods could be affecting the global logger. WithField for example could "stick" and turn up in logs for other requests when intention was to use it for one request with one context.

Not returning pointers makes it more safe.

#### What this PR does / why we need it (English/Chinese):

Changes so that receiver functions for the logger are not returning a reference to the global hlog logger.

Also some fixes and improvements to the readme.

