### PR TITLE
feat(zap): add multiple zapcore support

### DIFF
--- a/zap/README.md
+++ b/zap/README.md
@@ -38,4 +38,119 @@ func main() {
 }
 ```
 
+Multiple `zapcore` Example:
+
+```go
+package main
+
+import (
+	"github.com/cloudwego/hertz/pkg/common/hlog"
+	hertzzap "github.com/hertz-contrib/logger/zap"
+	"github.com/natefinch/lumberjack"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"os"
+)
+
+func main() {
+	dynamicLevel := zap.NewAtomicLevel()
+
+	dynamicLevel.SetLevel(zap.DebugLevel)
+
+	logger := hertzzap.NewLogger(
+		hertzzap.WithCores([]hertzzap.CoreConfig{
+			{
+				Enc: zapcore.NewConsoleEncoder(humanEncoderConfig()),
+				Ws:  os.Stdout,
+				Lvl: dynamicLevel,
+			},
+			{
+				Enc: zapcore.NewJSONEncoder(humanEncoderConfig()),
+				Ws:  getWriteSyncer("./all/log.log"),
+				Lvl: zap.NewAtomicLevelAt(zapcore.DebugLevel),
+			},
+			{
+				Enc: zapcore.NewJSONEncoder(humanEncoderConfig()),
+				Ws:  getWriteSyncer("./debug/log.log"),
+				Lvl: zap.NewAtomicLevelAt(zapcore.LevelOf(
+					zap.LevelEnablerFunc(func(lev zapcore.Level) bool {
+						return lev == zap.DebugLevel
+					}))),
+			},
+			{
+				Enc: zapcore.NewJSONEncoder(humanEncoderConfig()),
+				Ws:  getWriteSyncer("./info/log.log"),
+				Lvl: zap.NewAtomicLevelAt(zapcore.LevelOf(
+					zap.LevelEnablerFunc(func(lev zapcore.Level) bool {
+						return lev == zap.InfoLevel
+					}))),
+			},
+			{
+				Enc: zapcore.NewJSONEncoder(humanEncoderConfig()),
+				Ws:  getWriteSyncer("./warn/log.log"),
+				Lvl: zap.NewAtomicLevelAt(zapcore.LevelOf(
+					zap.LevelEnablerFunc(func(lev zapcore.Level) bool {
+						return lev == zap.WarnLevel
+					}))),
+			},
+			{
+				Enc: zapcore.NewJSONEncoder(humanEncoderConfig()),
+				Ws:  getWriteSyncer("./error/log.log"),
+				Lvl: zap.NewAtomicLevelAt(zapcore.LevelOf(
+					zap.LevelEnablerFunc(func(lev zapcore.Level) bool {
+						return lev >= zap.ErrorLevel
+					}))),
+			},
+		}...),
+	)
+	defer logger.Sync()
+
+	hlog.Infof("hello %s", "hertz")
+}
+
+// humanEncoderConfig copy from zap
+func humanEncoderConfig() zapcore.EncoderConfig {
+	cfg := testEncoderConfig()
+	cfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	cfg.EncodeLevel = zapcore.CapitalLevelEncoder
+	cfg.EncodeDuration = zapcore.StringDurationEncoder
+	return cfg
+}
+
+func getWriteSyncer(file string) zapcore.WriteSyncer {
+	lumberJackLogger := &lumberjack.Logger{
+		Filename:   file,
+		MaxSize:    10,
+		MaxBackups: 50000,
+		MaxAge:     1000,
+		Compress:   true,
+		LocalTime:  true,
+	}
+	return zapcore.AddSync(lumberJackLogger)
+}
+
+// testEncoderConfig encoder config for testing, copy from zap
+func testEncoderConfig() zapcore.EncoderConfig {
+	return zapcore.EncoderConfig{
+		MessageKey:     "msg",
+		LevelKey:       "level",
+		NameKey:        "name",
+		TimeKey:        "ts",
+		CallerKey:      "caller",
+		FunctionKey:    "func",
+		StacktraceKey:  "stacktrace",
+		LineEnding:     "\n",
+		EncodeTime:     zapcore.EpochTimeEncoder,
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeDuration: zapcore.SecondsDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+	}
+}
+```
+
+## Attention
+
+Method `SetLevel()` and `SetOutput()` only affect the first `zapcore` if imported multiple `zapcore`
+
+
 > For some reason, zap don't support log context info yet.

--- a/zap/option.go
+++ b/zap/option.go
@@ -31,19 +31,19 @@ func (fn option) apply(cfg *config) {
 	fn(cfg)
 }
 
-type coreConfig struct {
-	enc zapcore.Encoder
-	ws  zapcore.WriteSyncer
-	lvl zap.AtomicLevel
+type CoreConfig struct {
+	Enc zapcore.Encoder
+	Ws  zapcore.WriteSyncer
+	Lvl zap.AtomicLevel
 }
 
 type config struct {
-	coreConfig coreConfig
-	zapOpts    []zap.Option
+	coreConfigs []CoreConfig
+	zapOpts     []zap.Option
 }
 
 // defaultCoreConfig default zapcore config: json encoder, atomic level, stdout write syncer
-func defaultCoreConfig() *coreConfig {
+func defaultCoreConfig() *CoreConfig {
 	// default log encoder
 	enc := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
 	// default log level
@@ -51,40 +51,46 @@ func defaultCoreConfig() *coreConfig {
 	// default write syncer stdout
 	ws := zapcore.AddSync(os.Stdout)
 
-	return &coreConfig{
-		enc: enc,
-		ws:  ws,
-		lvl: lvl,
+	return &CoreConfig{
+		Enc: enc,
+		Ws:  ws,
+		Lvl: lvl,
 	}
 }
 
 // defaultConfig default config
 func defaultConfig() *config {
-	coreConfig := defaultCoreConfig()
 	return &config{
-		coreConfig: *coreConfig,
-		zapOpts:    []zap.Option{},
+		coreConfigs: []CoreConfig{*defaultCoreConfig()},
+		zapOpts:     []zap.Option{},
 	}
 }
 
 // WithCoreEnc zapcore encoder
 func WithCoreEnc(enc zapcore.Encoder) Option {
 	return option(func(cfg *config) {
-		cfg.coreConfig.enc = enc
+		cfg.coreConfigs[0].Enc = enc
 	})
 }
 
 // WithCoreWs zapcore write syncer
 func WithCoreWs(ws zapcore.WriteSyncer) Option {
 	return option(func(cfg *config) {
-		cfg.coreConfig.ws = ws
+		cfg.coreConfigs[0].Ws = ws
 	})
 }
 
 // WithCoreLevel zapcore log level
 func WithCoreLevel(lvl zap.AtomicLevel) Option {
 	return option(func(cfg *config) {
-		cfg.coreConfig.lvl = lvl
+		cfg.coreConfigs[0].Lvl = lvl
+	})
+}
+
+// WithCores zapcore
+func WithCores(coreConfigs ...CoreConfig) Option {
+	return option(func(cfg *config) {
+		cfg.coreConfigs = coreConfigs
 	})
 }
 


### PR DESCRIPTION
#### What type of PR is this?

feat

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):

目前`hlog`的`zap`扩展不支持使用多个`zapcore`的场景，比如我既需要输出到控制台，又需要输出到日志文件

<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
