### PR TITLE
feat: upgrade zerolog version and set context

### DIFF
--- a/zerolog/go.mod
+++ b/zerolog/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/cloudwego/hertz v0.4.0
-	github.com/rs/zerolog v1.28.0
+	github.com/rs/zerolog v1.30.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/zerolog/go.sum
+++ b/zerolog/go.sum
@@ -8,6 +8,7 @@ github.com/cloudwego/hertz v0.4.0 h1:qigNIzhOpydsEgenCCHoLObQgkumg7aPR7MvvkbeVuo
 github.com/cloudwego/hertz v0.4.0/go.mod h1:QSD2254yaf43BIy4isrlfKR42R3uFAT+6G5CpeROOJs=
 github.com/cloudwego/netpoll v0.2.6/go.mod h1:1T2WVuQ+MQw6h6DpE45MohSvDTKdy2DlzCx2KsnPI4E=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -45,8 +46,11 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=
 github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
+github.com/rs/zerolog v1.30.0 h1:SymVODrcRsaRaSInD9yQtKbtWqwsfoPcRff/oRXLj4c=
+github.com/rs/zerolog v1.30.0/go.mod h1:/tk+P47gFdPXq4QYjvCmT5/Gsug2nagsFWBWhAiSi1w=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/zerolog/logger.go
+++ b/zerolog/logger.go
@@ -139,17 +139,17 @@ func (l *Logger) CtxLogf(level hlog.Level, ctx context.Context, format string, k
 	// todo add hook
 	switch level {
 	case hlog.LevelTrace, hlog.LevelDebug:
-		logger.Debug().Msg(fmt.Sprintf(format, kvs...))
+		logger.Debug().Ctx(ctx).Msg(fmt.Sprintf(format, kvs...))
 	case hlog.LevelInfo:
-		logger.Info().Msg(fmt.Sprintf(format, kvs...))
+		logger.Info().Ctx(ctx).Msg(fmt.Sprintf(format, kvs...))
 	case hlog.LevelNotice, hlog.LevelWarn:
-		logger.Warn().Msg(fmt.Sprintf(format, kvs...))
+		logger.Warn().Ctx(ctx).Msg(fmt.Sprintf(format, kvs...))
 	case hlog.LevelError:
-		logger.Error().Msg(fmt.Sprintf(format, kvs...))
+		logger.Error().Ctx(ctx).Msg(fmt.Sprintf(format, kvs...))
 	case hlog.LevelFatal:
-		logger.Fatal().Msg(fmt.Sprintf(format, kvs...))
+		logger.Fatal().Ctx(ctx).Msg(fmt.Sprintf(format, kvs...))
 	default:
-		logger.Warn().Msg(fmt.Sprintf(format, kvs...))
+		logger.Warn().Ctx(ctx).Msg(fmt.Sprintf(format, kvs...))
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it (English/Chinese):

1. 升级 zerolog 版本从 1.28.0 -> 1.30.0
2. logger.CtxLogf() 传递 ctx 到 zerolog

#### Which issue(s) this PR fixes:

Fixes #38 
