### PR TITLE
doc(zap): correct document content(#43)

### DIFF
--- a/zap/README.md
+++ b/zap/README.md
@@ -101,6 +101,7 @@ func main() {
 	)
 	defer logger.Sync()
 
+	hlog.SetLogger(logger)
 	hlog.Infof("hello %s", "hertz")
 }
 


### PR DESCRIPTION

#### What type of PR is this?
This is a PR about docs

#### What this PR does / why we need it (English/Chinese):

fix functions in the Multiple zapcore Example section, adding a call to `hlog.SetLooger(logger)` to inject hertzzap logger instances into the hlog.FullLooger interface

#### Which issue(s) this PR fixes:
#43
