### PR TITLE
fix: Fix request latency output with default template.

### DIFF
--- a/accesslog/accesslog.go
+++ b/accesslog/accesslog.go
@@ -105,8 +105,6 @@ func new(ctx context.Context, opts ...Option) app.HandlerFunc {
 	}
 
 	return func(ctx context.Context, c *app.RequestContext) {
-		var start, stop time.Time
-
 		// Logger data
 		data := dataPool.Get().(*Data) //nolint:forcetypeassert,errcheck // We store nothing else in the pool
 		// no need for a reset, as long as we always override everything
@@ -139,7 +137,7 @@ func new(ctx context.Context, opts ...Option) app.HandlerFunc {
 			_, _ = buf.WriteString(fmt.Sprintf(defaultFormat,
 				timestamp,
 				c.Response.StatusCode(),
-				stop.Sub(start),
+				data.Stop.Sub(data.Start),
 				c.Method(),
 				c.Path(),
 			))


### PR DESCRIPTION
…en using the default template.

Associated issue： https://github.com/hertz-contrib/logger/issues/56

#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):
When using the default template, the request latency can be correctly output.
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:
Fixes #<56>
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
